### PR TITLE
Add SwiftPhysicsEngine example

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftPhysicsEngine",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "SwiftPhysicsEngine",
+            targets: ["SwiftPhysicsEngine"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "SwiftPhysicsEngine"),
+        .testTarget(
+            name: "SwiftPhysicsEngineTests",
+            dependencies: ["SwiftPhysicsEngine"]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -32,3 +32,30 @@ integer arithmetic expressions.
 
 The resulting `test.exe` will exit with the value computed in the `return`
 statement. Only very basic integer expressions are supported.
+
+## SwiftPhysicsEngine
+
+This repository also includes **SwiftPhysicsEngine**, a minimal 2D physics engine written in Swift. The engine is designed for educational purposes and showcases how to implement vectors, rigid bodies, collision detection, and impulse resolution.
+
+### Building and Testing
+
+Run the unit tests using Swift Package Manager:
+
+```bash
+swift test
+```
+
+### Example Usage
+
+```
+import SwiftPhysicsEngine
+
+let world = World()
+let body = Body(position: Vec2(x: 0, y: 10), mass: 1)
+let shape = PhysicsBodyComponent(rigidBody: body, shape: PhysicsCircle(radius: 1))
+world.addBody(shape)
+world.step(deltaTime: 1.0)
+print(body.position)
+```
+
+This will simulate a single step with gravity acting on the body.

--- a/Sources/SwiftPhysicsEngine/Collision.swift
+++ b/Sources/SwiftPhysicsEngine/Collision.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public struct Contact {
+    public var normal: Vector2
+    public var penetration: Double
+}
+
+public struct Manifold {
+    public var contacts: [Contact] = []
+}
+
+public class Collision {
+    public static func circleVsCircle(posA: Vector2, radA: Double, posB: Vector2, radB: Double) -> Manifold? {
+        let delta = posB - posA
+        let dist2 = delta.lengthSquared
+        let radiusSum = radA + radB
+        if dist2 >= radiusSum * radiusSum {
+            return nil
+        }
+        let distance = sqrt(dist2)
+        let penetration = radiusSum - distance
+        let normal = distance > 0 ? delta / distance : Vector2(x: 1, y: 0)
+        return Manifold(contacts: [Contact(normal: normal, penetration: penetration)])
+    }
+
+    public static func aabbVsAabb(posA: Vector2, boxA: AABB, posB: Vector2, boxB: AABB) -> Manifold? {
+        let diff = posB - posA
+        let overlapX = boxA.halfWidth + boxB.halfWidth - abs(diff.x)
+        if overlapX <= 0 { return nil }
+        let overlapY = boxA.halfHeight + boxB.halfHeight - abs(diff.y)
+        if overlapY <= 0 { return nil }
+
+        if overlapX < overlapY {
+            let normal = Vector2(x: diff.x < 0 ? -1 : 1, y: 0)
+            return Manifold(contacts: [Contact(normal: normal, penetration: overlapX)])
+        } else {
+            let normal = Vector2(x: 0, y: diff.y < 0 ? -1 : 1)
+            return Manifold(contacts: [Contact(normal: normal, penetration: overlapY)])
+        }
+    }
+}

--- a/Sources/SwiftPhysicsEngine/PhysicsWorld.swift
+++ b/Sources/SwiftPhysicsEngine/PhysicsWorld.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+public class PhysicsBody {
+    public var rigidBody: RigidBody
+    public var shape: Shape
+
+    public init(rigidBody: RigidBody, shape: Shape) {
+        self.rigidBody = rigidBody
+        self.shape = shape
+    }
+}
+
+public class PhysicsWorld {
+    public var bodies: [PhysicsBody] = []
+    public var gravity: Vector2 = Vector2(x: 0, y: -9.8)
+
+    public init() {}
+
+    public func addBody(_ body: PhysicsBody) {
+        bodies.append(body)
+    }
+
+    public func step(deltaTime: Double) {
+        // Apply gravity
+        for body in bodies {
+            body.rigidBody.applyForce(gravity * body.rigidBody.mass)
+        }
+
+        // Integrate
+        for body in bodies {
+            body.rigidBody.integrate(deltaTime: deltaTime)
+        }
+
+        // Collision detection and resolution
+        let count = bodies.count
+        for i in 0..<count {
+            for j in i+1..<count {
+                handleCollision(bodyA: bodies[i], bodyB: bodies[j])
+            }
+        }
+    }
+
+    private func handleCollision(bodyA: PhysicsBody, bodyB: PhysicsBody) {
+        if let circleA = bodyA.shape as? Circle, let circleB = bodyB.shape as? Circle {
+            if let manifold = Collision.circleVsCircle(posA: bodyA.rigidBody.position, radA: circleA.radius, posB: bodyB.rigidBody.position, radB: circleB.radius) {
+                resolve(manifold: manifold, bodyA: bodyA.rigidBody, bodyB: bodyB.rigidBody)
+            }
+        } else if let boxA = bodyA.shape as? AABB, let boxB = bodyB.shape as? AABB {
+            if let manifold = Collision.aabbVsAabb(posA: bodyA.rigidBody.position, boxA: boxA, posB: bodyB.rigidBody.position, boxB: boxB) {
+                resolve(manifold: manifold, bodyA: bodyA.rigidBody, bodyB: bodyB.rigidBody)
+            }
+        }
+    }
+
+    private func resolve(manifold: Manifold, bodyA: RigidBody, bodyB: RigidBody) {
+        guard let contact = manifold.contacts.first else { return }
+        let relativeVelocity = bodyB.velocity - bodyA.velocity
+        let velocityAlongNormal = relativeVelocity.x * contact.normal.x + relativeVelocity.y * contact.normal.y
+        if velocityAlongNormal > 0 { return }
+
+        let restitution = min(bodyA.restitution, bodyB.restitution)
+        let j = -(1 + restitution) * velocityAlongNormal / (bodyA.inverseMass + bodyB.inverseMass)
+        let impulse = contact.normal * j
+        bodyA.velocity.add(impulse * -bodyA.inverseMass)
+        bodyB.velocity.add(impulse * bodyB.inverseMass)
+
+        // Positional correction
+        let percent = 0.8
+        let slop = 0.01
+        let correctionMagnitude = max(contact.penetration - slop, 0) / (bodyA.inverseMass + bodyB.inverseMass) * percent
+        let correction = contact.normal * correctionMagnitude
+        bodyA.position.add(correction * -bodyA.inverseMass)
+        bodyB.position.add(correction * bodyB.inverseMass)
+    }
+}

--- a/Sources/SwiftPhysicsEngine/RigidBody.swift
+++ b/Sources/SwiftPhysicsEngine/RigidBody.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public class RigidBody {
+    public var position: Vector2
+    public var velocity: Vector2
+    public var force: Vector2 = .zero
+    public var mass: Double
+    public var inverseMass: Double
+    public var restitution: Double
+
+    public init(position: Vector2 = .zero, velocity: Vector2 = .zero, mass: Double = 1.0, restitution: Double = 0.5) {
+        self.position = position
+        self.velocity = velocity
+        self.mass = mass
+        self.restitution = restitution
+        self.inverseMass = mass > 0 ? 1.0 / mass : 0.0
+    }
+
+    public func applyForce(_ f: Vector2) {
+        force.add(f)
+    }
+
+    public func integrate(deltaTime: Double) {
+        guard inverseMass > 0 else { return }
+        // Update velocity from accumulated force
+        let acceleration = force * inverseMass
+        velocity.add(acceleration * deltaTime)
+        // Update position from velocity
+        position.add(velocity * deltaTime)
+        // Reset force
+        force = .zero
+    }
+}

--- a/Sources/SwiftPhysicsEngine/Shape.swift
+++ b/Sources/SwiftPhysicsEngine/Shape.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public protocol Shape {}
+
+public struct Circle: Shape {
+    public var radius: Double
+    public init(radius: Double) {
+        self.radius = radius
+    }
+}
+
+public struct AABB: Shape {
+    public var halfWidth: Double
+    public var halfHeight: Double
+    public init(halfWidth: Double, halfHeight: Double) {
+        self.halfWidth = halfWidth
+        self.halfHeight = halfHeight
+    }
+}

--- a/Sources/SwiftPhysicsEngine/SwiftPhysicsEngine.swift
+++ b/Sources/SwiftPhysicsEngine/SwiftPhysicsEngine.swift
@@ -1,0 +1,14 @@
+// 2D Physics Engine for Teaching Purposes
+// Provides basic rigid body integration, gravity, collision detection, and impulse resolution.
+
+import Foundation
+
+// The module re-exports everything for simplicity
+public typealias Vec2 = Vector2
+public typealias Body = RigidBody
+public typealias PhysicsShape = Shape
+public typealias PhysicsCircle = Circle
+public typealias PhysicsAABB = AABB
+public typealias PhysicsBodyComponent = PhysicsBody
+public typealias World = PhysicsWorld
+public typealias CollisionDetection = Collision

--- a/Sources/SwiftPhysicsEngine/Vector2.swift
+++ b/Sources/SwiftPhysicsEngine/Vector2.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+// Conform to Sendable so it can be safely used across concurrency domains
+
+public struct Vector2: Sendable {
+    public var x: Double
+    public var y: Double
+
+    public init(x: Double = 0, y: Double = 0) {
+        self.x = x
+        self.y = y
+    }
+
+    public static let zero = Vector2()
+
+    public static func +(lhs: Vector2, rhs: Vector2) -> Vector2 {
+        Vector2(x: lhs.x + rhs.x, y: lhs.y + rhs.y)
+    }
+
+    public static func -(lhs: Vector2, rhs: Vector2) -> Vector2 {
+        Vector2(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
+    }
+
+    public static func *(lhs: Vector2, rhs: Double) -> Vector2 {
+        Vector2(x: lhs.x * rhs, y: lhs.y * rhs)
+    }
+
+    public static func /(lhs: Vector2, rhs: Double) -> Vector2 {
+        Vector2(x: lhs.x / rhs, y: lhs.y / rhs)
+    }
+
+    public mutating func add(_ other: Vector2) {
+        x += other.x
+        y += other.y
+    }
+
+    public mutating func scale(by scalar: Double) {
+        x *= scalar
+        y *= scalar
+    }
+
+    public var lengthSquared: Double {
+        x * x + y * y
+    }
+
+    public var length: Double {
+        sqrt(lengthSquared)
+    }
+
+    public func normalized() -> Vector2 {
+        let len = length
+        if len > 0 {
+            return self / len
+        }
+        return .zero
+    }
+}

--- a/Tests/SwiftPhysicsEngineTests/SwiftPhysicsEngineTests.swift
+++ b/Tests/SwiftPhysicsEngineTests/SwiftPhysicsEngineTests.swift
@@ -1,0 +1,15 @@
+import Testing
+@testable import SwiftPhysicsEngine
+
+@Test func simulationWorks() async throws {
+    let world = World()
+    world.gravity = Vec2(x: 0, y: -10)
+    let bodyA = Body(position: Vec2(x: 0, y: 0), mass: 1.0)
+    let bodyB = Body(position: Vec2(x: 0, y: 5), mass: 1.0)
+    let circleA = PhysicsBodyComponent(rigidBody: bodyA, shape: PhysicsCircle(radius: 1))
+    let circleB = PhysicsBodyComponent(rigidBody: bodyB, shape: PhysicsCircle(radius: 1))
+    world.addBody(circleA)
+    world.addBody(circleB)
+    world.step(deltaTime: 1.0)
+    #expect(bodyA.position.y < 0)
+}


### PR DESCRIPTION
## Summary
- implement a simple 2D physics engine in Swift
- add vector math, rigid bodies, collision detection, and a world stepper
- provide a minimal unit test demonstrating physics integration
- document the new SwiftPhysicsEngine in the README

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6883bb24fb34832eb6ff9fbf0718b9f1