### PR TITLE
Add JSON-driven web interface builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.build/
 build/
 develop-eggs/
 dist/

--- a/Examples/dashboard_layout.json
+++ b/Examples/dashboard_layout.json
@@ -1,0 +1,67 @@
+{
+  "title": "Product Analytics Dashboard",
+  "theme": {
+    "body": {
+      "fontFamily": "Inter, system-ui, sans-serif",
+      "backgroundColor": "#f5f5f7",
+      "margin": "0",
+      "padding": "2rem"
+    },
+    "components": {
+      ".panel": {
+        "backgroundColor": "#fff",
+        "borderRadius": "12px",
+        "boxShadow": "0 10px 30px rgba(26, 26, 67, 0.08)",
+        "padding": "1.5rem"
+      },
+      ".primary": {
+        "backgroundColor": "#4f46e5",
+        "color": "#fff",
+        "border": "none",
+        "padding": "0.75rem 1.5rem",
+        "borderRadius": "999px",
+        "cursor": "pointer"
+      }
+    }
+  },
+  "customCss": ".grid { display: grid; gap: 1.25rem; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }",
+  "components": [
+    {
+      "type": "container",
+      "className": "grid",
+      "children": [
+        {
+          "type": "container",
+          "className": "panel",
+          "children": [
+            {"type": "text", "tag": "h1", "text": "Weekly Summary"},
+            {"type": "text", "tag": "p", "text": "Monitor retention, engagement, and conversion at a glance."},
+            {"type": "button", "className": "primary", "text": "Create Report"}
+          ]
+        },
+        {
+          "type": "container",
+          "className": "panel",
+          "children": [
+            {"type": "text", "tag": "h2", "text": "Active Users"},
+            {"type": "text", "tag": "p", "text": "68,420 monthly active"},
+            {"type": "text", "tag": "p", "text": "+12% vs last month"}
+          ]
+        },
+        {
+          "type": "container",
+          "className": "panel",
+          "children": [
+            {"type": "text", "tag": "h2", "text": "Funnels"},
+            {"type": "text", "tag": "p", "text": "86% onboarding completion"},
+            {
+              "type": "input",
+              "placeholder": "Filter segment",
+              "attributes": {"aria-label": "Filter funnel"}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -59,3 +59,30 @@ print(body.position)
 ```
 
 This will simulate a single step with gravity acting on the body.
+
+## Interface Builder for Web Apps
+
+Need to sketch product dashboards or marketing pages without hand-writing HTML
+every time? The repository now ships with `web_interface_builder.py`, a tiny
+interface builder that turns JSON layout descriptions into static HTML.
+
+### Usage
+
+1. Describe your layout in JSON. The `Examples/dashboard_layout.json` file shows
+   a full specification including theming, reusable class selectors, and nested
+   components.
+2. Run the builder to turn the JSON into HTML:
+
+   ```bash
+   python web_interface_builder.py Examples/dashboard_layout.json build/dashboard.html
+   ```
+
+   If you omit the second argument the script will emit an `.html` file next to
+   your JSON spec automatically.
+3. Open the generated HTML in a browser to review the interface, tweak the JSON
+   as needed, and regenerate.
+
+Supported component types today include `container`, `text`, `button`, `input`,
+and `image`. Each component can opt into inline styles, extra attributes (for
+ARIA labels, test hooks, etc.), and nested children to approximate the behavior
+of visual interface builders.

--- a/web_interface_builder.py
+++ b/web_interface_builder.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Simple interface builder for web applications.
+
+This script consumes a JSON layout description and produces a static HTML file
+that reflects the described user interface. The workflow mirrors a lightweight
+"interface builder" experience for web apps, letting teams tweak structured
+layout primitives without hand-authoring repetitive markup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, MutableMapping
+
+Component = Mapping[str, Any]
+LayoutSpec = Mapping[str, Any]
+
+SUPPORTED_COMPONENTS = {
+    "container",
+    "text",
+    "button",
+    "input",
+    "image",
+}
+
+
+def camel_to_kebab(value: str) -> str:
+    result: List[str] = []
+    for char in value:
+        if char.isupper():
+            result.append("-")
+            result.append(char.lower())
+        else:
+            result.append(char)
+    return "".join(result)
+
+
+def build_style_string(styles: Mapping[str, Any] | None) -> str | None:
+    if not styles:
+        return None
+    css_chunks = []
+    for key, value in styles.items():
+        if value is None:
+            continue
+        css_chunks.append(f"{camel_to_kebab(key)}: {value}")
+    return "; ".join(css_chunks) if css_chunks else None
+
+
+def build_attributes(component: Component) -> str:
+    attrs: MutableMapping[str, str] = {}
+    if component.get("id"):
+        attrs["id"] = str(component["id"])
+    if component.get("className"):
+        attrs["class"] = str(component["className"])
+    if component.get("attributes"):
+        for key, value in component["attributes"].items():
+            if value is not None:
+                attrs[key] = str(value)
+    style_string = build_style_string(component.get("styles"))
+    if style_string:
+        attrs["style"] = style_string
+    attr_chunks = [f'{key}="{html.escape(value, quote=True)}"' for key, value in attrs.items()]
+    return (" " + " ".join(attr_chunks)) if attr_chunks else ""
+
+
+def render_component(component: Component, indent: int = 4) -> str:
+    component_type = component.get("type")
+    if component_type not in SUPPORTED_COMPONENTS:
+        raise ValueError(f"Unsupported component type: {component_type}")
+
+    indent_str = " " * indent
+    attributes = build_attributes(component)
+
+    if component_type == "container":
+        children = component.get("children", [])
+        if not isinstance(children, list):
+            raise ValueError("Container children must be a list of components")
+        if not children:
+            return f"{indent_str}<div{attributes}></div>"
+        rendered_children = "\n".join(
+            render_component(child, indent=indent + 2) for child in children
+        )
+        return f"{indent_str}<div{attributes}>\n{rendered_children}\n{indent_str}</div>"
+
+    if component_type == "text":
+        tag = component.get("tag", "p")
+        text_content = html.escape(str(component.get("text", "")))
+        return f"{indent_str}<{tag}{attributes}>{text_content}</{tag}>"
+
+    if component_type == "button":
+        label = html.escape(str(component.get("text", "Button")))
+        return f"{indent_str}<button{attributes}>{label}</button>"
+
+    if component_type == "input":
+        placeholder = component.get("placeholder")
+        placeholder_attr = (
+            f' placeholder="{html.escape(str(placeholder))}"' if placeholder else ""
+        )
+        base = f"{indent_str}<input{attributes}{placeholder_attr}"
+        if component.get("selfClosing", True):
+            return base + " />"
+        return base + "></input>"
+
+    if component_type == "image":
+        src = html.escape(str(component.get("src", "")))
+        alt = html.escape(str(component.get("alt", "")))
+        return f"{indent_str}<img src=\"{src}\" alt=\"{alt}\"{attributes} />"
+
+    raise ValueError(f"Unhandled component type: {component_type}")
+
+
+def render_body(components: Iterable[Component]) -> str:
+    rendered = [render_component(component) for component in components]
+    return "\n".join(rendered)
+
+
+def build_theme_css(theme: Mapping[str, Any] | None) -> str:
+    if not theme:
+        return ""
+
+    body_styles = build_style_string(theme.get("body"))
+    css_blocks = []
+    if body_styles:
+        css_blocks.append(f"body {{ {body_styles}; }}")
+    if theme.get("components"):
+        for selector, style_dict in theme["components"].items():
+            style_string = build_style_string(style_dict)
+            if style_string:
+                css_blocks.append(f"{selector} {{ {style_string}; }}")
+    return "\n".join(css_blocks)
+
+
+def generate_html(spec: LayoutSpec) -> str:
+    title = html.escape(str(spec.get("title", "Interface Builder Page")))
+    components = spec.get("components", [])
+    theme_css = build_theme_css(spec.get("theme"))
+    custom_css = spec.get("customCss", "")
+    stylesheets = spec.get("stylesheets", [])
+
+    head_parts = [f"<title>{title}</title>"]
+    for sheet in stylesheets:
+        head_parts.append(
+            f'<link rel="stylesheet" href="{html.escape(str(sheet), quote=True)}">'
+        )
+    inline_css_blocks = [block for block in (theme_css, custom_css) if block]
+    if inline_css_blocks:
+        head_parts.append("<style>\n" + "\n".join(inline_css_blocks) + "\n</style>")
+
+    head_html = "\n    ".join(head_parts)
+    body_html = render_body(components)
+    body_block = ("\n" + body_html + "\n  ") if body_html else ""
+
+    return (
+        "<!DOCTYPE html>\n"
+        "<html lang=\"en\">\n"
+        "  <head>\n"
+        f"    {head_html}\n"
+        "  </head>\n"
+        "  <body>"
+        f"{body_block}"
+        "\n  </body>\n"
+        "</html>\n"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate static HTML layouts from JSON specifications."
+    )
+    parser.add_argument("spec", type=Path, help="Path to the JSON layout description.")
+    parser.add_argument(
+        "output",
+        type=Path,
+        nargs="?",
+        help=(
+            "Optional path to the HTML file. Defaults to replacing the spec extension with .html."
+        ),
+    )
+    return parser.parse_args()
+
+
+def load_spec(path: Path) -> LayoutSpec:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Unable to parse {path}: {exc}") from exc
+
+
+def main() -> None:
+    args = parse_args()
+    spec_path: Path = args.spec
+    if not spec_path.exists():
+        raise SystemExit(f"Spec file {spec_path} does not exist.")
+
+    spec = load_spec(spec_path)
+    html_output = generate_html(spec)
+    output_path = args.output or spec_path.with_suffix(".html")
+    output_path.write_text(html_output, encoding="utf-8")
+    print(f"Generated {output_path} from {spec_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python-based interface builder that converts JSON layout specs into HTML and ship an example dashboard layout
- document how to use the new interface builder workflow in the README
- ignore SwiftPM's `.build` artifacts so they are not accidentally committed

## Testing
- swift test
- python web_interface_builder.py Examples/dashboard_layout.json /tmp/dashboard.html

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915bc5b88cc832ebe3940239290be85)