### PR TITLE
Add ArchiveOrgClient Swift package for Archive.org API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,15 +10,25 @@ let package = Package(
         .library(
             name: "SwiftPhysicsEngine",
             targets: ["SwiftPhysicsEngine"]),
+        .library(
+            name: "ArchiveOrgClient",
+            targets: ["ArchiveOrgClient"]
+        )
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "SwiftPhysicsEngine"),
+        .target(
+            name: "ArchiveOrgClient"),
         .testTarget(
             name: "SwiftPhysicsEngineTests",
             dependencies: ["SwiftPhysicsEngine"]
         ),
+        .testTarget(
+            name: "ArchiveOrgClientTests",
+            dependencies: ["ArchiveOrgClient"]
+        )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -37,6 +37,47 @@ statement. Only very basic integer expressions are supported.
 
 This repository also includes **SwiftPhysicsEngine**, a minimal 2D physics engine written in Swift. The engine is designed for educational purposes and showcases how to implement vectors, rigid bodies, collision detection, and impulse resolution.
 
+## ArchiveOrgClient (Swift)
+
+`ArchiveOrgClient` is a small Swift package for interacting with the Archive.org API from iOS or macOS apps. It wraps common endpoints such as advanced search, item metadata, and file downloads using Swift concurrency.
+
+### Adding the Package
+
+Add this repository as a dependency in your `Package.swift`:
+
+```
+.package(url: "https://github.com/your/repo.git", from: "1.0.0")
+```
+
+Then depend on the library product:
+
+```
+ .target(
+     name: "YourAppTarget",
+     dependencies: [
+         .product(name: "ArchiveOrgClient", package: "SwiftPhysicsEngine")
+     ]
+ )
+```
+
+### Example Usage
+
+```
+import ArchiveOrgClient
+
+let client = ArchiveOrgClient()
+
+Task {
+    let results = try await client.search(query: "collection:(smithsonian)")
+    print("Found \(results.numFound) items")
+
+    if let identifier = results.docs.first?.identifier {
+        let metadata = try await client.itemMetadata(identifier: identifier)
+        print("First file: \(metadata.files.first?.name ?? "n/a")")
+    }
+}
+```
+
 ### Building and Testing
 
 Run the unit tests using Swift Package Manager:

--- a/Sources/ArchiveOrgClient/ArchiveOrgClient.swift
+++ b/Sources/ArchiveOrgClient/ArchiveOrgClient.swift
@@ -1,0 +1,142 @@
+import Foundation
+import FoundationNetworking
+
+/// A lightweight client for the Archive.org HTTP API.
+public final class ArchiveOrgClient {
+    public enum ClientError: Error, Equatable {
+        case invalidURL
+        case unexpectedStatusCode(Int)
+        case decodingFailed
+        case requestFailed(Error)
+
+        public static func == (lhs: ClientError, rhs: ClientError) -> Bool {
+            switch (lhs, rhs) {
+            case (.invalidURL, .invalidURL):
+                return true
+            case let (.unexpectedStatusCode(a), .unexpectedStatusCode(b)):
+                return a == b
+            case (.decodingFailed, .decodingFailed):
+                return true
+            case let (.requestFailed(a), .requestFailed(b)):
+                return (a as NSError).domain == (b as NSError).domain && (a as NSError).code == (b as NSError).code
+            default:
+                return false
+            }
+        }
+    }
+
+    private let session: URLSession
+    private let baseURL: URL
+
+    /// Creates a new client instance.
+    /// - Parameters:
+    ///   - session: The URLSession used to perform requests. Defaults to ``URLSession.shared``.
+    ///   - baseURL: The Archive.org API base URL. Defaults to ``https://archive.org``.
+    public init(session: URLSession = .shared, baseURL: URL = URL(string: "https://archive.org")!) {
+        self.session = session
+        self.baseURL = baseURL
+    }
+
+    /// Performs an advanced search query.
+    /// - Parameters:
+    ///   - query: The search query string.
+    ///   - page: The page index (1-based).
+    ///   - rows: The number of results per page.
+    ///   - fields: Specific fields to request. Uses Archive.org defaults when not provided.
+    /// - Returns: A decoded ``ArchiveSearchResponse``.
+    public func search(
+        query: String,
+        page: Int = 1,
+        rows: Int = 50,
+        fields: [String]? = nil
+    ) async throws -> ArchiveSearchResponse {
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        components?.path = "/advancedsearch.php"
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "output", value: "json"),
+            URLQueryItem(name: "page", value: String(page)),
+            URLQueryItem(name: "rows", value: String(rows))
+        ]
+
+        if let fields, !fields.isEmpty {
+            queryItems.append(contentsOf: fields.map { URLQueryItem(name: "fl[]", value: $0) })
+        }
+
+        components?.queryItems = queryItems
+
+        guard let url = components?.url else { throw ClientError.invalidURL }
+        let searchContainer: ArchiveSearchContainer = try await performRequest(url: url)
+        return searchContainer.response
+    }
+
+    /// Retrieves metadata for an Archive.org item.
+    /// - Parameter identifier: The Archive.org item identifier.
+    /// - Returns: Decoded item metadata including the file listing.
+    public func itemMetadata(identifier: String) async throws -> ArchiveItemMetadata {
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        components?.path = "/metadata/\(identifier)"
+
+        guard let url = components?.url else { throw ClientError.invalidURL }
+        return try await performRequest(url: url)
+    }
+
+    /// Downloads a specific file associated with an Archive.org item.
+    /// - Parameters:
+    ///   - identifier: The Archive.org item identifier.
+    ///   - fileName: The file name from the item's metadata response.
+    /// - Returns: Raw file data.
+    public func downloadFile(identifier: String, fileName: String) async throws -> Data {
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        components?.path = "/download/\(identifier)/\(fileName)"
+
+        guard let url = components?.url else { throw ClientError.invalidURL }
+        return try await performRawRequest(url: url)
+    }
+
+    // MARK: - Internal Helpers
+
+    private func performRequest<T: Decodable>(url: URL) async throws -> T {
+        let request = URLRequest(url: url)
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw ClientError.unexpectedStatusCode(-1)
+            }
+
+            guard (200 ... 299).contains(httpResponse.statusCode) else {
+                throw ClientError.unexpectedStatusCode(httpResponse.statusCode)
+            }
+
+            do {
+                return try JSONDecoder().decode(T.self, from: data)
+            } catch {
+                throw ClientError.decodingFailed
+            }
+        } catch let error as ClientError {
+            throw error
+        } catch {
+            throw ClientError.requestFailed(error)
+        }
+    }
+
+    private func performRawRequest(url: URL) async throws -> Data {
+        let request = URLRequest(url: url)
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw ClientError.unexpectedStatusCode(-1)
+            }
+
+            guard (200 ... 299).contains(httpResponse.statusCode) else {
+                throw ClientError.unexpectedStatusCode(httpResponse.statusCode)
+            }
+
+            return data
+        } catch let error as ClientError {
+            throw error
+        } catch {
+            throw ClientError.requestFailed(error)
+        }
+    }
+}

--- a/Sources/ArchiveOrgClient/Models.swift
+++ b/Sources/ArchiveOrgClient/Models.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public struct ArchiveSearchContainer: Decodable {
+    public let response: ArchiveSearchResponse
+}
+
+public struct ArchiveSearchResponse: Decodable, Equatable {
+    public let numFound: Int
+    public let start: Int
+    public let docs: [ArchiveSearchDocument]
+}
+
+public struct ArchiveSearchDocument: Decodable, Equatable {
+    public let identifier: String
+    public let title: String?
+    public let creator: [String]?
+    public let collection: [String]?
+    public let mediatype: String?
+}
+
+public struct ArchiveItemMetadata: Decodable, Equatable {
+    public let metadata: ArchiveItemDetails
+    public let files: [ArchiveFile]
+}
+
+public struct ArchiveItemDetails: Decodable, Equatable {
+    public let identifier: String
+    public let title: String?
+    public let creator: [String]?
+    public let description: [String]?
+    public let subject: [String]?
+}
+
+public struct ArchiveFile: Decodable, Equatable {
+    public let name: String
+    public let size: Int64?
+    public let format: String?
+    public let md5: String?
+    public let sha1: String?
+    public let mtime: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case size
+        case format
+        case md5
+        case sha1
+        case mtime
+    }
+}

--- a/Tests/ArchiveOrgClientTests/ArchiveOrgClientTests.swift
+++ b/Tests/ArchiveOrgClientTests/ArchiveOrgClientTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import FoundationNetworking
+import XCTest
+@testable import ArchiveOrgClient
+
+final class ArchiveOrgClientTests: XCTestCase {
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    func testSearchDecoding() async throws {
+        let searchJSON = """
+        {
+          "response": {
+            "numFound": 1,
+            "start": 0,
+            "docs": [
+              {
+                "identifier": "test_item",
+                "title": "Test Item",
+                "creator": ["Test Creator"],
+                "collection": ["texts"],
+                "mediatype": "texts"
+              }
+            ]
+          }
+        }
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, searchJSON)
+        }
+
+        let session = makeSession()
+        let client = ArchiveOrgClient(session: session)
+        let result = try await client.search(query: "test")
+
+        XCTAssertEqual(result.numFound, 1)
+        XCTAssertEqual(result.docs.first?.identifier, "test_item")
+        XCTAssertEqual(result.docs.first?.title, "Test Item")
+    }
+
+    func testMetadataDecoding() async throws {
+        let metadataJSON = """
+        {
+          "metadata": {
+            "identifier": "test_item",
+            "title": "Test Item",
+            "creator": ["Creator"],
+            "description": ["A test item"],
+            "subject": ["Testing"]
+          },
+          "files": [
+            {
+              "name": "sample.txt",
+              "size": 1234,
+              "format": "Text",
+              "md5": "abc",
+              "sha1": "def",
+              "mtime": 1700000000
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, metadataJSON)
+        }
+
+        let session = makeSession()
+        let client = ArchiveOrgClient(session: session)
+        let metadata = try await client.itemMetadata(identifier: "test_item")
+
+        XCTAssertEqual(metadata.metadata.identifier, "test_item")
+        XCTAssertEqual(metadata.files.first?.name, "sample.txt")
+        XCTAssertEqual(metadata.files.first?.size, 1234)
+    }
+
+    func testUnexpectedStatusCodeThrows() async {
+        let errorData = Data()
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+            return (response, errorData)
+        }
+
+        let session = makeSession()
+        let client = ArchiveOrgClient(session: session)
+
+        do {
+            _ = try await client.search(query: "test")
+            XCTFail("Expected to throw")
+        } catch let error as ArchiveOrgClient.ClientError {
+            XCTAssertEqual(error, .unexpectedStatusCode(500))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/Tests/ArchiveOrgClientTests/MockURLProtocol.swift
+++ b/Tests/ArchiveOrgClientTests/MockURLProtocol.swift
@@ -1,0 +1,32 @@
+import Foundation
+import FoundationNetworking
+
+final class MockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## Summary
- add a new ArchiveOrgClient library for Archive.org search, metadata, and file download endpoints
- introduce strongly typed models and URLProtocol-based tests for client behavior
- document how to integrate and use the client in the README

## Testing
- swift test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920fe2c27cc832e8d03b97f8bbda2da)